### PR TITLE
fixup bug as description in #39

### DIFF
--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -36,6 +36,18 @@ private:
           func();
         }
       }
+
+      // If the task queue is not empty, continue obtain task from task queue, 
+      // the multithread continues execution until the queue is empty
+      while (!m_pool->m_queue.empty()) {
+        {
+          std::unique_lock<std::mutex> lock(m_pool->m_conditional_mutex);
+          dequeued = m_pool->m_queue.dequeue(func);
+          if (dequeued) {
+            func();
+          }
+        }
+      }
     }
   };
 


### PR DESCRIPTION
I found that `m_queue.size()` isn't equal to zero when `pool.shutdown()` was runned, so some tasks do not finish when the thread pool closes.

I fixed it up as follows:

```cpp
void operator()() {
  std::function<void()> func;
  bool dequeued;
  while (!m_pool->m_shutdown) {
    {
      std::unique_lock<std::mutex> lock(m_pool->m_conditional_mutex);
      if (m_pool->m_queue.empty()) {
        m_pool->m_conditional_lock.wait(lock);
      }
      dequeued = m_pool->m_queue.dequeue(func);
    }
    if (dequeued) {
      func();
    }
  }

  // If the task queue is not empty, continue obtain task from task queue, 
  // the multithread continues execution until the queue is empty
  while (!m_pool->m_queue.empty()) {
    {
      std::unique_lock<std::mutex> lock(m_pool->m_conditional_mutex);
      dequeued = m_pool->m_queue.dequeue(func);
      if (dequeued) {
        func();
      }
    }
  }
}
```